### PR TITLE
drop panel plots for igas

### DIFF
--- a/analysis/report/report_weekly.ipynb
+++ b/analysis/report/report_weekly.ipynb
@@ -63,7 +63,6 @@
    "outputs": [],
    "source": [
     "display(Markdown(\"#### Amoxicillin\"))\n",
-    "display_event_counts(\"event_counts_amoxicillin.json\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_top_5(\"top_5_code_table_event_code_amoxicillin_rate.csv\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"amoxicillin_by_subgroup_count.png\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"amoxicillin_by_subgroup.png\", dir=WEEKLY_RESULTS_DIR)"
@@ -76,7 +75,6 @@
    "outputs": [],
    "source": [
     "display(Markdown(\"#### Azithromycin\"))\n",
-    "display_event_counts(\"event_counts_azithromycin.json\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_top_5(\"top_5_code_table_event_code_azithromycin_rate.csv\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"azithromycin_by_subgroup_count.png\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"azithromycin_by_subgroup.png\", dir=WEEKLY_RESULTS_DIR)"
@@ -89,7 +87,6 @@
    "outputs": [],
    "source": [
     "display(Markdown(\"#### Clarithromycin\"))\n",
-    "display_event_counts(\"event_counts_clarithromycin.json\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_top_5(\"top_5_code_table_event_code_clarithromycin_rate.csv\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"clarithromycin_by_subgroup_count.png\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"clarithromycin_by_subgroup.png\", dir=WEEKLY_RESULTS_DIR)"
@@ -102,7 +99,6 @@
    "outputs": [],
    "source": [
     "display(Markdown(\"#### Erythromycin\"))\n",
-    "display_event_counts(\"event_counts_erythromycin.json\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_top_5(\"top_5_code_table_event_code_erythromycin_rate.csv\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"erythromycin_by_subgroup_count.png\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"erythromycin_by_subgroup.png\", dir=WEEKLY_RESULTS_DIR)"
@@ -115,7 +111,6 @@
    "outputs": [],
    "source": [
     "display(Markdown(\"#### Phenoxymethypenicillin\"))\n",
-    "display_event_counts(\"event_counts_phenoxymethypenicillin.json\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_top_5(\"top_5_code_table_event_code_phenoxymethypenicillin_rate.csv\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"phenoxymethypenicillin_by_subgroup_count.png\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"phenoxymethypenicillin_by_subgroup.png\", dir=WEEKLY_RESULTS_DIR)"
@@ -148,7 +143,6 @@
    "outputs": [],
    "source": [
     "display(Markdown(\"#### Scarlet Fever\"))\n",
-    "display_event_counts(\"event_counts_scarlet_fever.json\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_top_5(\"top_5_code_table_event_code_scarlet_fever_rate.csv\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"scarlet_fever_by_subgroup_count.png\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"scarlet_fever_by_subgroup.png\", dir=WEEKLY_RESULTS_DIR)\n",
@@ -164,7 +158,6 @@
    "outputs": [],
    "source": [
     "display(Markdown(\"#### Invasive Strep A\"))\n",
-    "display_event_counts(\"event_counts_invasive_strep_a.json\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_top_5(\"top_5_code_table_event_code_invasive_strep_a_rate.csv\", dir=WEEKLY_RESULTS_DIR)\n"
    ]
   },
@@ -175,7 +168,6 @@
    "outputs": [],
    "source": [
     "display(Markdown(\"#### Strep A Sore Throat\"))\n",
-    "display_event_counts(\"event_counts_strep_a_sore_throat.json\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_top_5(\"top_5_code_table_event_code_strep_a_sore_throat_rate.csv\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"strep_a_sore_throat_by_subgroup_count.png\", dir=WEEKLY_RESULTS_DIR)\n",
     "display_image(\"strep_a_sore_throat_by_subgroup.png\", dir=WEEKLY_RESULTS_DIR)\n",
@@ -201,7 +193,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.5 (default, Jun 10 2021, 10:02:47) \n[Clang 12.0.5 (clang-1205.0.22.9)]"
   },
   "orig_nbformat": 4,
   "vscode": {


### PR DESCRIPTION
Drops the panel plots for invasive strep a from the weekly notebook, but retains the event count summary and top 5 codes.