### PR TITLE
Remove weekly 3

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -283,7 +283,7 @@ actions:
   generate_study_population_report_weekly_2:
     run: cohortextractor:latest generate_cohort
       --study-definition study_definition_report
-      --index-date-range "2022-11-10 to 2023-01-18 by week"
+      --index-date-range "2022-11-10 to 2023-01-25 by week"
       --param frequency=weekly
       --output-dir=output/report/weekly
       --output-format=csv.gz


### PR DESCRIPTION
Weekly 3 was added when we wanted to extend without re-running. It did not have that many weeks, and was actually already covered by weekly 2.