### PR TITLE
Use combine_codelists for the _with_ variables

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -41,6 +41,7 @@ actions:
       --param frequency=weekly
       --output-dir=output/curation
       --output-format=csv.gz
+      --skip-existing
     outputs:
       highly_sensitive:
         cohort: output/curation/input_report_2022-07-01.csv.gz
@@ -55,6 +56,13 @@ actions:
         moderately_sensitive:
           # Only output the single summary file
           cohort_report: output/curation/input_report_2022-07-01.html
+
+  curation_measures_weekly:
+    run: cohortextractor:latest generate_measures --study-definition study_definition_report --output-dir=output/curation --skip-existing
+    needs: [curation_weekly]
+    outputs:
+      moderately_sensitive:
+        measure_csv: output/curation/measure_event_*_rate.csv
 
   curation_diagnostics:
     run: cohortextractor:latest generate_cohort


### PR DESCRIPTION
As part of https://github.com/opensafely/strepa_scarlet/issues/54, we want to see

1. How slow is it to add the _with_ measures using combine_codelists rather than each combination individually?
2. Can we fix the _with_ measures so that they make sense?
3. Does --skip-existing work?

We can do this in two steps

Step 1 (this step):
Extract *_with_clinical_any and *_with_medication_any using the combined codelists for one month
The --skip-existing flag has been added, and -7/+14 days has been changed to the exact date
**Leave the weekly study definition alone in case we want to kick off another weekly extract on Monday/Tuesday

Step 2:
Add an additional month (or 3?) to the project yaml
Do not make any other modifications to the study def to assess whether skip existing worked
See whether we still see the cyclical pattern on the _with_ variables

No _with_ variables
`output_column_count=45 table_count=28 table_joins_count=28`

All of the _with_ variables
`output_column_count=104 table_count=76 table_joins_count=76`

Use combine codelists for the _with_ variables
`output_column_count=56 table_count=39 table_joins_count=39`

* A note: the measures framework does not accept --param, so we do not extract ANY ethnicity measures for now; we might want to re-add this when we run the monthly report