### PR TITLE
Explore date range and with variable matches

### DIFF
--- a/analysis/study_definition_with_curation.py
+++ b/analysis/study_definition_with_curation.py
@@ -30,8 +30,8 @@ def generate_expectations_codes(codelist, incidence=0.5):
     return expectations
 
 
-start_date = "2019-01-01"
-end_date = "2022-01-01"
+start_date = "2018-01-01"
+end_date = "2018-04-01"
 
 study = StudyDefinition(
     index_date=start_date,
@@ -59,20 +59,22 @@ study = StudyDefinition(
         between=["index_date", "last_day_of_month(index_date)"],
         returning="binary_flag",
         include_date_of_match=True,
-        date_format="YYYY-MM",
+        date_format="YYYY-MM-DD",
         return_expectations={
             "incidence": 0.5,
-            "date": {"earliest": "1900-01-01", "latest": "today"},
         },
+    ),
+    scarlet_fever_date_short=patients.date_of(
+        "scarlet_fever", date_format="YYYY-MM"
     ),
     any_prescription=patients.with_these_medications(
         codelist=any_medication_codes,
         between=["index_date", "last_day_of_month(index_date)"],
         returning="binary_flag",
         include_date_of_match=True,
+        date_format="YYYY-MM-DD",
         return_expectations={
             "incidence": 0.5,
-            "date": {"earliest": "1900-01-01", "latest": "today"},
         },
     ),
     any_prescription_count=patients.with_these_medications(
@@ -108,6 +110,14 @@ study = StudyDefinition(
         between=[
             "scarlet_fever_date",
             "scarlet_fever_date",
+        ],
+        returning="binary_flag",
+    ),
+    scarlet_fever_with_medication_any_same_day_short=patients.with_these_medications(
+        codelist=any_medication_codes,
+        between=[
+            "scarlet_fever_date_short",
+            "scarlet_fever_date_short",
         ],
         returning="binary_flag",
     ),

--- a/analysis/templates/dataset_report.html
+++ b/analysis/templates/dataset_report.html
@@ -31,6 +31,10 @@
         {{ impossible_early }}
         <p>Count of patients with dates after the current date</p>
         {{ impossible_date }}
+        {% if not diff.empty %}
+            <h2>Column Diff Summary</h2>
+            {{ diff }}
+        {% endif %}
     </article>
 </body>
 

--- a/project.yaml
+++ b/project.yaml
@@ -91,23 +91,24 @@ actions:
   curation_with:
     run: cohortextractor:latest generate_cohort
       --study-definition study_definition_with_curation
-      --index-date-range "2019-01-01 to 2019-02-01 by month"
+      --index-date-range "2018-01-01 to 2018-04-01 by month"
       --output-dir=output/curation
       --output-format=feather
     outputs:
       highly_sensitive:
-        cohort: output/curation/input_with_curation_2019-*-01.feather
+        cohort: output/curation/input_with_curation_2018-*-01.feather
 
   dataset_report_with:
       run: python:latest python analysis/dataset_report.py
-           --input-files output/curation/input_with_curation_2019-*-01.feather
+           --input-files output/curation/input_with_curation_2018-*-01.feather
            --output-dir output/curation/
            --granularity "day"
+           diff --col-1 "scarlet_fever_date" --col-2 "any_prescription_date"
       needs: [curation_with]
       outputs:
         moderately_sensitive:
           # Only output the single summary file
-          cohort_report: output/curation/input_with_curation_2019-*-01.html
+          cohort_report: output/curation/input_with_curation_2018-*-01.html
   ### End curation check ###
 
   ### MONTHLY ###


### PR DESCRIPTION
Here we explore two things:
1. The impact of date_format="YYYY-MM-DD" versus "YYYY-MM", as we think if the later is used in combination with -7 days + 14 days, it would always look -7 to +14 days after the first of the month. Compare the number of matches in the whole month, to -7 + 14 days, to same day with the full format string, to same day with the short format string

2. Count the number of days between a scarlet fever diagnosis and any antibiotic prescription and group the patients by the number of days. Apply redaction and rounding before displaying in the html report.