### PR TITLE
Keep measures for both rate and percentage

### DIFF
--- a/analysis/report/create_panels.py
+++ b/analysis/report/create_panels.py
@@ -91,7 +91,7 @@ def panels_with(measure_table, output_dir, frequency, xtick_frequency):
             column_to_plot=column_to_plot,
             columns=2,
             date_lines=None,
-            scale="percentage",
+            scale="rate",
             ci=None,
             exclude_group="Missing",
             output_dir=output_dir,

--- a/analysis/study_definition_report.py
+++ b/analysis/study_definition_report.py
@@ -85,7 +85,6 @@ def generate_all_clinical():
 
 
 def generate_expectations_codes(codelist, incidence=0.5):
-
     expectations = {str(x): (1 - incidence) / 10 for x in codelist[0:10]}
     expectations[None] = incidence
     return expectations
@@ -348,6 +347,13 @@ for medication_key in list(medication_codelists.keys()):
                 Measure(
                     id=f"event_{medication_key}_with_clinical_any_rate",
                     numerator=f"{medication_key}_with_clinical_any",
+                    denominator="population",
+                    group_by=["population"],
+                    small_number_suppression=True,
+                ),
+                Measure(
+                    id=f"event_{medication_key}_with_clinical_any_pcnt",
+                    numerator=f"{medication_key}_with_clinical_any",
                     denominator=f"event_{medication_key}",
                     group_by=["population"],
                     small_number_suppression=True,
@@ -409,10 +415,17 @@ for clinical_key in list(clinical_event_codelists.keys()):
                 Measure(
                     id=f"event_{clinical_key}_with_medication_any_rate",
                     numerator=f"{clinical_key}_with_medication_any",
+                    denominator="population",
+                    group_by=["population"],
+                    small_number_suppression=True,
+                ),
+                Measure(
+                    id=f"event_{clinical_key}_with_medication_any_pcnt",
+                    numerator=f"{clinical_key}_with_medication_any",
                     denominator=f"event_{clinical_key}",
                     group_by=["population"],
                     small_number_suppression=True,
-                )
+                ),
             ]
         )
 

--- a/project.yaml
+++ b/project.yaml
@@ -65,7 +65,7 @@ actions:
     needs: [curation_weekly]
     outputs:
       moderately_sensitive:
-        measure_csv: output/curation/measure_event_*_rate.csv
+        measure_csv: output/curation/measure_event_*.csv
 
   curation_diagnostics:
     run: cohortextractor:latest generate_cohort
@@ -204,11 +204,12 @@ actions:
     needs: [join_cohorts_report]
     outputs:
       moderately_sensitive:
-        measure_csv: output/report/joined/measure_event_*_rate.csv
+        measure_csv: output/report/joined/measure_event_*.csv
 
   join_measures_rounded:
       run: python:latest python analysis/join_and_round.py
-           --input-files output/report/joined/measure_*_rate.csv
+           --input-files output/report/joined/measure_event_*_rate.csv
+           --input-files output/report/joined/measure_event_*_pcnt.csv
            --exclude-files output/report/joined/measure_*practice*_rate.csv
            --exclude-files output/report/joined/measure_event_code*_rate.csv
            --output-dir output/report/results


### PR DESCRIPTION
The rate of patients with a prescription and clinical indication over the total population is probably more clinically helpful than the percentage (over patients with a prescription).

Change the primary measures to be over the population (that is the measure that will be picked up by the plots and the report), and create a new measure for the percentage.