### PR TITLE
add custom `add_percentiles` function

### DIFF
--- a/analysis/report/panel_plots.py
+++ b/analysis/report/panel_plots.py
@@ -149,7 +149,7 @@ def add_percentiles(df, period_column=None, column=None, show_outer_percentiles=
     df = df.groupby(period_column)[column].quantile(quantiles).reset_index()
     df = df.rename(index=str, columns={"level_1": "percentile"})
     # create integer range of percentiles
-    df["percentile"] = df["percentile"].apply(lambda x: x * 100)
+    df["percentile"] = df["percentile"].apply(lambda x: round(x * 100))
     return df
 
 


### PR DESCRIPTION
`charts.add_percentiles` has a bug where a decile value is repeated if outer percentiles are included. This custom version fixes that bug