### PR TITLE
Paper figures

### DIFF
--- a/analysis/report/group_medications.py
+++ b/analysis/report/group_medications.py
@@ -1,0 +1,55 @@
+import pandas as pd
+import argparse
+import pathlib
+from report_utils import get_measure_tables, GROUPED_MEDICATIONS
+
+
+def group_medications(medications_df):
+    by_line = []
+    for line, meds in GROUPED_MEDICATIONS.items():
+        criteria = "(" + "|".join(meds) + ")"
+        medications = medications_df[
+            medications_df.name.str.contains("|".join(meds))
+        ]
+        medications.name = medications.name.str.replace(
+            criteria, line, regex=True
+        )
+        medications = medications.groupby(
+            ["date", "category", "group", "name"], as_index=False
+        ).agg({"numerator": "sum", "denominator": lambda x: x.iloc[0]})
+        medications["value"] = (
+            medications["numerator"] / medications["denominator"]
+        )
+        medications["rate"] = 1000 * medications["value"]
+        by_line.append(medications)
+    return pd.concat(by_line)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--measure-path", help="path of combined measure file")
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        type=pathlib.Path,
+        help="Path to the output directory",
+    )
+    args = parser.parse_args()
+
+    return args
+
+
+def main():
+    args = parse_args()
+    measure_path = args.measure_path
+    output_dir = args.output_dir
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    df = get_measure_tables(measure_path)
+    grouped = group_medications(df)
+    grouped.to_csv(output_dir / "grouped_measures.csv", index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/report/panel_plots.py
+++ b/analysis/report/panel_plots.py
@@ -464,6 +464,7 @@ def get_group_chart(
         ax.tick_params(axis="y", labelsize="small")
         ax.yaxis.label.set_alpha(1.0)
         ax.yaxis.label.set_fontsize("small")
+        ax.set_ylim(bottom=0)
 
         # TODO: this will apply the same date range limits to each axis
         if not stack_years and frequency == "month":

--- a/analysis/report/panel_plots.py
+++ b/analysis/report/panel_plots.py
@@ -400,7 +400,7 @@ def get_group_chart(
 
     lgds = []
     for index, panel in enumerate(groups):
-        sns.set_style("darkgrid")
+        sns.set_style("whitegrid")
         # set the color palette using matplotlib
         plt.rcParams["axes.prop_cycle"] = plt.cycler(color=colour_palette)
 

--- a/analysis/report/panel_plots.py
+++ b/analysis/report/panel_plots.py
@@ -16,6 +16,7 @@ from report_utils import (
     drop_zero_denominator_rows,
     filename_to_title,
     autoselect_labels,
+    is_bool_as_int,
     translate_group,
     get_measure_tables,
     subset_table,
@@ -69,28 +70,6 @@ def plot_cis(ax, data):
         (data["ci95hi"]),
         alpha=0.1,
     )
-
-
-def is_bool_as_int(series):
-    """Does series have bool values but an int dtype?"""
-    # numpy.nan will ensure an int series becomes a float series, so we need to
-    # check for both int and float
-    if not pandas.api.types.is_bool_dtype(
-        series
-    ) and pandas.api.types.is_numeric_dtype(series):
-        series = series.dropna()
-        return ((series == 0) | (series == 1)).all()
-    elif not pandas.api.types.is_bool_dtype(
-        series
-    ) and pandas.api.types.is_object_dtype(series):
-        try:
-            series = series.astype(int)
-        except ValueError:
-            return False
-        series = series.dropna()
-        return ((series == 0) | (series == 1)).all()
-    else:
-        return False
 
 
 def reorder_dataframe(measure_table, order):

--- a/analysis/report/panel_plots.py
+++ b/analysis/report/panel_plots.py
@@ -251,7 +251,6 @@ def deciles_chart(
             loc=6,  # which part of the bounding box should
             #  be placed at bbox_to_anchor
             ncol=1,  # number of columns in the legend
-            fontsize=12,
             borderaxespad=0.0,
         )  # padding between the axes and legend
         #  specified in font-size units
@@ -379,7 +378,6 @@ def get_group_chart(
     lgd_params = {
         "bbox_to_anchor": (1, 1),
         "loc": "upper left",
-        "fontsize": "10",
         "ncol": 1,
     }
 
@@ -457,11 +455,12 @@ def get_group_chart(
         )
     # Deciles chart code globally calls plt.gcf().autofmt_xdate()
     # So we have to turn the axes back on here
+    # Use relative terms i.e. small (rather than 7) so basefontsize can scale
     for ax in plt.gcf().get_axes():
         ax.tick_params(labelbottom=True)
         ax.get_xticklabels("auto")
         ax.set_xlabel("")
-        ax.tick_params(axis="x", labelsize=7, rotation=90)
+        ax.tick_params(axis="x", labelsize="small", rotation=90)
         ax.tick_params(axis="y", labelsize="small")
         ax.yaxis.label.set_alpha(1.0)
         ax.yaxis.label.set_fontsize("small")

--- a/analysis/report/pcnt_table.py
+++ b/analysis/report/pcnt_table.py
@@ -1,0 +1,111 @@
+import pathlib
+import argparse
+import pandas
+import fnmatch
+
+from report_utils import ci_95_proportion, ci_to_str
+
+
+def get_measure_tables(input_file):
+    measure_table = pandas.read_csv(
+        input_file,
+        dtype={"numerator": float, "denominator": float, "value": float},
+        na_values="[REDACTED]",
+    )
+
+    return measure_table
+
+
+def subset_table(measure_table, measures_pattern, date):
+    """
+    Given either a pattern of list of names, extract the subset of a joined
+    measures file based on the 'name' column
+    """
+
+    measure_table = measure_table[measure_table["date"] == date]
+
+    measures_list = []
+    for pattern in measures_pattern:
+        paths_to_add = match_paths(measure_table["name"], pattern)
+        if len(paths_to_add) == 0:
+            raise ValueError(f"Pattern did not match any rows: {pattern}")
+        measures_list += paths_to_add
+
+    table_subset = measure_table[measure_table["name"].isin(measures_list)]
+
+    if table_subset.empty:
+        raise ValueError("Patterns did not match any rows")
+
+    return table_subset
+
+
+def match_paths(files, pattern):
+    return fnmatch.filter(files, pattern)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input-file",
+        required=True,
+        help="Path to single joined measures file",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        type=pathlib.Path,
+        help="Path to the output directory",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    input_file = args.input_file
+    output_dir = args.output_dir
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    measure_table = get_measure_tables(input_file)
+
+    end_date = measure_table.date.max()
+    medications = subset_table(
+        measure_table, ["event_*_with_clinical_any_pcnt"], end_date
+    )
+    medications.index = pandas.MultiIndex.from_product(
+        [
+            ["Medication with clinical any"],
+            list(
+                medications.name.str.extract(
+                    r"event_(\w+)_with_clinical_any_pcnt", expand=False
+                ).str.title()
+            ),
+        ]
+    )
+    medications = medications.sort_values("value", ascending=False)
+    medications_cis = ci_to_str(
+        ci_95_proportion(medications, scale=100), decimals=1
+    )
+    clinical = subset_table(
+        measure_table, ["event_*_with_medication_any_pcnt"], end_date
+    )
+    clinical.index = pandas.MultiIndex.from_product(
+        [
+            ["Clinical with medication any"],
+            list(
+                clinical.name.str.extract(
+                    r"event_(\w+)_with_medication_any_pcnt", expand=False
+                ).str.title()
+            ),
+        ]
+    )
+    clinical = clinical.sort_values("value", ascending=False)
+    clinical_cis = ci_to_str(ci_95_proportion(clinical, scale=100), decimals=1)
+    joined = pandas.concat([medications_cis, clinical_cis])
+    joined.name = "Percent (95% CI)"
+    table = pandas.DataFrame(joined)
+    table.to_html(output_dir / "pcnt_with_indication.html", index=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/report/plot_measures_report.py
+++ b/analysis/report/plot_measures_report.py
@@ -5,8 +5,6 @@ import pathlib
 import matplotlib.pyplot as plt
 import seaborn as sns
 from report_utils import (
-    ci_to_str,
-    ci_95_proportion,
     add_date_lines,
     autoselect_labels,
     colour_palette,
@@ -14,6 +12,8 @@ from report_utils import (
     parse_date,
     coerce_numeric,
     set_fontsize,
+    make_season_table,
+    annotate_seasons,
     MEDICATION_TO_CODELIST,
     CLINICAL_TO_CODELIST,
 )
@@ -21,87 +21,6 @@ from report_utils import (
 import matplotlib.ticker as ticker
 
 ticker.Locator.MAXTICKS = 10000
-
-
-# NOTE: bug with pandas 1.01, cannot do pivot with MultiIndex
-def MultiIndex_pivot(
-    df: pd.DataFrame,
-    index: str = None,
-    columns: str = None,
-    values: str = None,
-) -> pd.DataFrame:
-    """
-    https://github.com/pandas-dev/pandas/issues/23955
-    Usage:
-    df.pipe(MultiIndex_pivot, index = ['idx_column1', 'idx_column2'],
-            columns = ['col_column1', 'col_column2'], values = 'bar')
-    """
-    output_df = df.copy(deep=True)
-    if index is None:
-        names = list(output_df.index.names)
-        output_df.reset_index(drop=True, inplace=True)
-    else:
-        names = index
-    output_df = output_df.assign(
-        tuples_index=[tuple(i) for i in output_df[names].values]
-    )
-    if isinstance(columns, list):
-        output_df = output_df.assign(
-            tuples_columns=[tuple(i) for i in output_df[columns].values]
-        )
-        output_df = output_df.pivot(
-            index="tuples_index", columns="tuples_columns", values=values
-        )
-        output_df.columns = pd.MultiIndex.from_tuples(
-            [((x[0],) + x[1]) for x in output_df.columns],
-            names=[None] + columns,
-        )
-    else:
-        output_df = output_df.pivot(
-            index="tuples_index", columns=columns, values=values
-        )
-    output_df.index = pd.MultiIndex.from_tuples(output_df.index, names=names)
-    return output_df
-
-
-def produce_min_max_table(df, column_to_plot, category):
-    df.numerator = df.numerator.astype(float)
-    df.denominator = df.denominator.astype(float)
-    cis = ci_95_proportion(df, scale=1000)
-    df["Rate (95% CI)"] = ci_to_str(cis)
-    df = df.rename({"numerator": "Count"}, axis=1)
-    table = df.pipe(
-        MultiIndex_pivot,
-        index=[category, "type"],
-        columns="gas_year",
-        values=["Count", "rate", "Rate (95% CI)"],
-    )
-    if column_to_plot == "numerator":
-        table["Count"] = table["Count"].applymap(lambda x: f"{x:.0f}")
-        return table["Count"]
-    else:
-        table.Count = table.Count.astype(float)
-        table.rate = table.rate.astype(float)
-        ratio = table["rate"]["2023"] / table["rate"]["2018"]
-
-        # See formula of ci irr:
-        # https://researchonline.lshtm.ac.uk/id/eprint/251164/1/pmed.1001270.s005.pdf
-        sd_log_irr = np.sqrt(
-            (1 / table["Count"]["2023"]) + (1 / table["Count"]["2018"])
-        )
-        lci = np.exp(np.log(ratio) - 1.96 * sd_log_irr)
-        uci = np.exp(np.log(ratio) + 1.96 * sd_log_irr)
-        rr_cis = pd.concat([ratio, lci, uci], axis=1)
-
-        rr_cis_str = ci_to_str(rr_cis)
-        rr_cis_str.name = ("2023 v 2018", "Rate Ratio (95% CI)")
-
-        # Create table with count, rate (95% CI)
-        table["Count"] = table["Count"].applymap(lambda x: f"{x:.0f}")
-        count_cis = (table[["Count", "Rate (95% CI)"]]).swaplevel(axis=1)
-        cols = count_cis.columns.get_level_values(0).unique()
-        reordered = count_cis.reindex(columns=cols, level="gas_year")
-        return pd.concat([reordered, rr_cis_str], axis=1)
 
 
 def plot_measures(
@@ -177,53 +96,14 @@ def plot_measures(
         ax.set_xticks(xticks)
         ax.set_xticklabels([x.strftime("%B %Y") for x in xticks])
 
+        # TODO: check that category exists?
         if produce_season_table or mark_seasons:
-            # TODO: check whether this works for weekly
-            df_copy["gas_year"] = pd.to_datetime(df_copy.index).to_period(
-                "A-Aug"
+            season_table = make_season_table(
+                df_copy, category, column_to_plot, output_dir, filename
             )
-            mins_and_maxes = []
-            for year, data in df_copy.groupby(["gas_year", category]):
-                data_sorted = data.dropna(subset=[column_to_plot]).sort_values(
-                    column_to_plot
-                )
-                if data_sorted.empty:
-                    continue
-                data_min = data_sorted.iloc[0]
-                data_max = data_sorted.iloc[-1]
-                if mark_seasons:
-                    plt.annotate(
-                        int(data_min[column_to_plot]),
-                        xy=(data_min.name, data_min[column_to_plot]),
-                        xytext=(0, 25),
-                        textcoords="offset points",
-                        verticalalignment="bottom",
-                        arrowprops=dict(facecolor="black", shrink=0.025),
-                        horizontalalignment="left"
-                        if (data_min.name.month % 2) == 1
-                        else "right",
-                        fontsize=12,
-                    )
-                    plt.annotate(
-                        int(data_max[column_to_plot]),
-                        xy=(data_max.name, data_max[column_to_plot]),
-                        xytext=(0, -25),
-                        textcoords="offset points",
-                        verticalalignment="top",
-                        arrowprops=dict(facecolor="blue", shrink=0.025),
-                        fontsize=12,
-                    )
-                data_min["type"] = "min"
-                data_max["type"] = "max"
-                mins_and_maxes.append(data_min)
-                mins_and_maxes.append(data_max)
-            if produce_season_table:
-                table = produce_min_max_table(
-                    pd.concat(mins_and_maxes, axis=1).T,
-                    column_to_plot,
-                    category,
-                )
-                table.to_html(output_dir / f"{filename}_table.html")
+            # TODO: check whether this works for weekly
+            if mark_seasons:
+                annotate_seasons(season_table, column_to_plot, ax)
 
     elif frequency == "week":
         xticks = pd.date_range(

--- a/analysis/report/plot_measures_report.py
+++ b/analysis/report/plot_measures_report.py
@@ -102,7 +102,7 @@ def plot_measures(
                 df_copy, category, column_to_plot, output_dir, filename
             )
             # TODO: check whether this works for weekly
-            if mark_seasons:
+            if season_table and mark_seasons:
                 annotate_seasons(season_table, column_to_plot, ax)
 
     elif frequency == "week":

--- a/analysis/report/plot_measures_report.py
+++ b/analysis/report/plot_measures_report.py
@@ -149,7 +149,7 @@ def plot_measures(
     """
     df_copy = df.copy()
 
-    sns.set_style("darkgrid")
+    sns.set_style("whitegrid")
     fig, ax = plt.subplots(figsize=(18, 10))
     plt.rcParams["axes.prop_cycle"] = plt.cycler(color=colour_palette)
     if log_scale:

--- a/analysis/report/plot_measures_report.py
+++ b/analysis/report/plot_measures_report.py
@@ -258,7 +258,7 @@ def plot_measures(
     plt.ylabel(y_label)
     plt.xlabel("Date")
     plt.xticks(rotation="vertical")
-    plt.xticks(fontsize=14)
+    plt.xticks(fontsize="medium")
 
     plt.ylim(
         top=1000 if df_copy[column_to_plot].isnull().all() else y_max,

--- a/analysis/report/plot_measures_report.py
+++ b/analysis/report/plot_measures_report.py
@@ -8,9 +8,9 @@ from report_utils import (
     add_date_lines,
     autoselect_labels,
     colour_palette,
+    get_measure_tables,
     translate_group,
     parse_date,
-    coerce_numeric,
     set_fontsize,
     make_season_table,
     annotate_seasons,
@@ -115,7 +115,7 @@ def plot_measures(
     if log_scale:
         ax.yaxis.set_major_formatter(ticker.ScalarFormatter())
         ax.yaxis.get_major_formatter().set_scientific(False)
-        y_label = f"Log {y_label.lower()}"
+        y_label = f"{y_label} (displayed on log scale)"
 
     plt.ylabel(y_label)
     plt.xlabel("Date")
@@ -215,8 +215,7 @@ def main():
     output_dir.mkdir(parents=True, exist_ok=True)
     set_fontsize(base_fontsize)
 
-    df = pd.read_csv(measure_path, parse_dates=["date"])
-    df = coerce_numeric(df)
+    df = get_measure_tables(measure_path)
     df["rate"] = 1000 * df["value"]
 
     population_measures = df[df.group == "population"]

--- a/analysis/report/report_utils.py
+++ b/analysis/report/report_utils.py
@@ -28,18 +28,19 @@ CLINICAL_TO_CODELIST = {
     "invasive_strep_a": "codelists/opensafely-invasive-group-a-strep.csv",
 }
 
+# NOTE: use dashes instead of underscores do autolabel doesn't remove
 GROUPED_MEDICATIONS = {
-    "group_1": [
+    "group-1": [
         "phenoxymethylpenicillin",
     ],
-    "group_2": [
+    "group-2": [
         "flucloxacillin",
         "amoxicillin",
         "clarithromycin",
         "erythromycin",
         "azithromycin",
     ],
-    "group_3": ["cefalexin", "co_amoxiclav"],
+    "group-3": ["cefalexin", "co_amoxiclav"],
 }
 
 

--- a/analysis/report/report_utils.py
+++ b/analysis/report/report_utils.py
@@ -328,9 +328,19 @@ def make_season_table(df, category, column_to_plot, output_dir, filename=None):
         data_max["type"] = "max"
         mins_and_maxes.append(data_min)
         mins_and_maxes.append(data_max)
-    table = pd.concat(mins_and_maxes, axis=1).T
+    try:
+        table = pd.concat(mins_and_maxes, axis=1).T
+        # Concatting and transposing seems to lose types
+        table.numerator = pd.to_numeric(table.numerator, errors="coerce")
+        table.denominator = pd.to_numeric(table.denominator, errors="coerce")
+    except ValueError:
+        return None
     if filename:
-        formatted = format_season_table(table, column_to_plot, category)
+        # If too much is redacted, we cannot make the table
+        try:
+            formatted = format_season_table(table, column_to_plot, category)
+        except KeyError:
+            return None
         formatted = reorder_dashes(formatted, level=0)
         formatted.to_html(output_dir / f"{filename}_table.html")
     return table

--- a/analysis/report/report_utils.py
+++ b/analysis/report/report_utils.py
@@ -137,6 +137,28 @@ def add_date_lines(vlines, min_date, max_date):
             plt.axvline(x=date, color="orange", ls="--")
 
 
+def is_bool_as_int(series):
+    """Does series have bool values but an int dtype?"""
+    # numpy.nan will ensure an int series becomes a float series, so we need to
+    # check for both int and float
+    if not pd.api.types.is_bool_dtype(
+        series
+    ) and pd.api.types.is_numeric_dtype(series):
+        series = series.dropna()
+        return ((series == 0) | (series == 1)).all()
+    elif not pd.api.types.is_bool_dtype(
+        series
+    ) and pd.api.types.is_object_dtype(series):
+        try:
+            series = series.astype(int)
+        except ValueError:
+            return False
+        series = series.dropna()
+        return ((series == 0) | (series == 1)).all()
+    else:
+        return False
+
+
 def reorder_dashes(data, level=1):
     """
     Some strings (i.e. numbers that contain dashes) should be sorted

--- a/analysis/report/report_utils.py
+++ b/analysis/report/report_utils.py
@@ -324,8 +324,8 @@ def format_season_table(df, column_to_plot, category):
     rr_cis_str = ci_to_str(rr_cis)
     rr_cis_str.name = ("2023 v 2018", "Rate Ratio (95% CI)")
 
-    # Create table with count, rate (95% CI)
-    table["Count"] = table["Count"].applymap(lambda x: f"{x:.0f}")
+    # Create table with (comma delimited) count, rate (95% CI)
+    table["Count"] = table["Count"].applymap(lambda x: f"{x:,.0f}")
     count_cis = (table[["Count", "Rate (95% CI)"]]).swaplevel(axis=1)
     cols = count_cis.columns.get_level_values(0).unique()
     reordered = count_cis.reindex(columns=cols, level="gas_year")

--- a/analysis/report/table1.py
+++ b/analysis/report/table1.py
@@ -51,8 +51,11 @@ def series_to_bool(series):
 
 
 def transform_percentage(x):
+    """
+    Return (comma delimited) x and column percentage
+    """
     transformed = (
-        x.map("{:.0f}".format)
+        x.map("{:,.0f}".format)
         + " ("
         + (((x / x.sum()) * 100).round(1)).astype(str)
         + ")"

--- a/analysis/report/tables.py
+++ b/analysis/report/tables.py
@@ -7,17 +7,7 @@ from report_utils import (
     subset_table,
 )
 import pandas
-
-
-def round_or_skip(x):
-    """
-    Try to return a value
-    If it fails, return the original value
-    """
-    try:
-        return round(float(x))
-    except Exception:
-        return x
+import numpy
 
 
 def count_table(measure_table):
@@ -96,10 +86,10 @@ def main():
     table = count_table(subset)
     table.index.name = table.index.name.title()
     table.index = table.index.strftime("%d-%m-%y")
-    # NOTE: applymap is by value (so very slow), but we have a mix of strings
-    # and numbers (REDACTED) so pandas.to_numeric will not work
-    # and the tables are small
-    table = table.applymap(round_or_skip)
+    # NOTE: applymap is by value (so very slow), but the tables are small
+    table = table.applymap(
+        lambda x: f"{x:,.0f}" if ~numpy.isnan(x) else "[REDACTED]"
+    )
     table.to_csv(output_dir / output_name)
 
 

--- a/analysis/report/top_5_report.py
+++ b/analysis/report/top_5_report.py
@@ -270,7 +270,7 @@ def plot_top_codes_over_time(
 
     plt.figure(figsize=(10, 6))
     # seaborn styling
-    sns.set_style("darkgrid")
+    sns.set_style("whitegrid")
     plt.rcParams["axes.prop_cycle"] = plt.cycler(color=colour_palette)
     ax = plt.gca()
 

--- a/analysis/report/top_5_report.py
+++ b/analysis/report/top_5_report.py
@@ -6,19 +6,13 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 
 from report_utils import (
-    coerce_numeric,
     round_values,
+    get_measure_tables,
     MEDICATION_TO_CODELIST,
     CLINICAL_TO_CODELIST,
     colour_palette,
     set_fontsize,
 )
-
-
-def get_measure_tables(input_file):
-    measure_table = pd.read_csv(input_file, dtype=str)
-
-    return measure_table
 
 
 def write_csv(df, path, **kwargs):
@@ -331,7 +325,6 @@ def main():
     set_fontsize(base_fontsize)
 
     measure_table = get_measure_tables(input_file)
-    measure_table = coerce_numeric(measure_table)
 
     all_codes = {**MEDICATION_TO_CODELIST, **CLINICAL_TO_CODELIST}
 

--- a/project.yaml
+++ b/project.yaml
@@ -270,6 +270,7 @@ actions:
       --panels "population" "practice" "age_band" "region" "imd" "ethnicity"
       --output-dir output/report/results
       --xtick-frequency 3
+      --base-fontsize 14
     needs: [join_measures_rounded, join_measures_unrounded]
     outputs:
       moderately_sensitive:
@@ -527,7 +528,6 @@ actions:
 
 
   ### Actions for paper ###
-
   table1:
     run: >
       python:latest python analysis/report/table1.py
@@ -543,23 +543,62 @@ actions:
       moderately_sensitive:
         tables: output/report/results/paper/table1.html
 
-  plot_measure_report_paper:
+  group_medications:
     run: >
-      python:latest python analysis/report/plot_measures_report.py
+      python:latest python analysis/report/group_medications.py
       --measure-path output/report/results/measure_rounded.csv
       --output-dir output/report/results/paper
-      --date-lines "2020-03-01" "2021-03-01"
-      --use-groups
-      --log-scale
-      --mark-seasons
-      --produce-season-table
-      --legend-inside
-      --base-fontsize 18
     needs: [join_measures_rounded]
     outputs:
       moderately_sensitive:
-        measure: output/report/results/paper/*_bar_measure*.jpeg
-        tables: output/report/results/paper/*_bar_measures_table.html
+        tables: output/report/results/paper/grouped_measures.csv
+
+
+  figure_1:
+    run: >
+      python:latest python analysis/report/panel_plots.py
+      --input-file output/report/results/measure_rounded.csv
+      --measures-list "event_sore_throat_tonsillitis_rate"
+      --measures-list "event_scarlet_fever_rate"
+      --measures-list "event_invasive_strep_a_rate"
+      --output-dir output/report/results/paper
+      --output-name "gas_clinical_events"
+      --date-lines "2020-03-01" "2021-03-01"
+      --column-to-plot "numerator"
+      --hide-legend
+      --columns 1
+      --base-fontsize 12
+      --xtick-frequency 2
+      --produce-season-table
+      --mark-seasons
+    needs: [join_measures_rounded]
+    outputs:
+      moderately_sensitive:
+        measure: output/report/results/paper/gas_clinical_events.png
+        tables: output/report/results/paper/gas_clinical_events_table.html
+
+  figure_2:
+    run: >
+      python:latest python analysis/report/panel_plots.py
+      --input-file output/report/results/paper/grouped_measures.csv
+      --measures-list "event_group-1_with_clinical_any_rate"
+      --measures-list "event_group-2_with_clinical_any_rate"
+      --measures-list "event_group-3_with_clinical_any_rate"
+      --output-dir output/report/results/paper
+      --output-name "grouped_medications_with"
+      --date-lines "2020-03-01" "2021-03-01"
+      --column-to-plot "numerator"
+      --hide-legend
+      --columns 1
+      --base-fontsize 12
+      --xtick-frequency 2
+      --produce-season-table
+      --mark-seasons
+    needs: [group_medications]
+    outputs:
+      moderately_sensitive:
+        measure: output/report/results/paper/grouped_medications_with.png
+        tables: output/report/results/paper/grouped_medications_with_table.html
 
   pheno_panel_plot_paper:
     run: >
@@ -575,8 +614,66 @@ actions:
       --exclude-group "Missing"
       --scale "rate"
       --xtick-frequency 3
-      --base-fontsize 18
+      --produce-season-table
+      --base-fontsize 12
+      --columns 1
     needs: [join_measures_rounded]
     outputs:
       moderately_sensitive:
         measure: output/report/results/paper/phenoxymethylpenicillin_with_clinical_any_by_subgroup.png
+        tables: output/report/results/paper/event_phenoxymethylpenicillin_with_clinical_any_age_band_rate_table.html
+
+  supplemental_antibiotics_groups:
+    run: >
+      python:latest python analysis/report/panel_plots.py
+      --input-file output/report/results/paper/grouped_measures.csv
+      --measures-list "event_group-1_rate"
+      --measures-list "event_group-2_rate"
+      --measures-list "event_group-3_rate"
+      --output-dir output/report/results/paper
+      --output-name "grouped_medications"
+      --date-lines "2020-03-01" "2021-03-01"
+      --column-to-plot "numerator"
+      --hide-legend
+      --columns 1
+      --base-fontsize 12
+      --xtick-frequency 2
+      --produce-season-table
+      --mark-seasons
+    needs: [group_medications]
+    outputs:
+      moderately_sensitive:
+        measure: output/report/results/paper/grouped_medications.png
+        tables: output/report/results/paper/grouped_medications_table.html
+
+
+  supplemental_antibiotic_with_gas:
+    run: >
+      python:latest python analysis/report/panel_plots.py
+      --input-file output/report/results/measure_rounded.csv
+      --measures-pattern "event_*_with_clinical_any_rate"
+      --output-dir output/report/results/paper
+      --output-name "antibiotic_with_clinical_any"
+      --date-lines "2020-03-01" "2021-03-01"
+      --column-to-plot "numerator"
+      --hide-legend
+      --columns 1
+      --base-fontsize 12
+      --xtick-frequency 2
+      --produce-season-table
+      --mark-seasons
+    needs: [join_measures_rounded]
+    outputs:
+      moderately_sensitive:
+        measure: output/report/results/paper/antibiotic_with_clinical_any.png
+        tables: output/report/results/paper/antibiotic_with_clinical_any_table.html
+
+  supplemental_table_with_pcnt:
+    run: >
+      python:latest python analysis/report/pcnt_table.py
+      --input-file output/report/results/measure_rounded.csv
+      --output-dir output/report/results/paper
+    needs: [join_measures_rounded]
+    outputs:
+      moderately_sensitive:
+        tables: output/report/results/paper/pcnt_with_indication.html


### PR DESCRIPTION
Given feedback on figures from team meeting, the main goals were
1. Remove dark background
2. Remove log scale, and replace with multi-panel figure
3. Make the figures "look better"

This was achieved by switching from using plot_measures_report to using panel_plots for paper figures 1 and 2, which meant a chunk of code that was in panel plots (grouping the medication measures, generating the season tables and annotating seasonal max/min) had to move from plot_measures report into the shared utilities.

Panel plots were also modified to make a 1 column panel plot look better, as the width makes the panels more legible.

The project yaml has been updated to ensure that all papers/figures (including supplemental) are captured in an action.